### PR TITLE
Add Remko RKL 360/460/470/480 Series AC Remote.

### DIFF
--- a/ACs/Remko/Remko_RKL.ir
+++ b/ACs/Remko/Remko_RKL.ir
@@ -1,0 +1,46 @@
+Filetype: IR signals file
+Version: 1
+#
+# Remko RKL 360/460/470/480 IR-Remote
+#
+name: POWER
+type: parsed
+protocol: NECext
+address: 86 6B 00 00
+command: 12 ED 00 00
+# 
+name: MODE
+type: parsed
+protocol: NECext
+address: 86 6B 00 00
+command: 02 FD 00 00
+# 
+name: SWING
+type: parsed
+protocol: NECext
+address: 86 6B 00 00
+command: 00 FF 00 00
+# 
+name: TEMP+
+type: parsed
+protocol: NECext
+address: 86 6B 00 00
+command: 1A E5 00 00
+# 
+name: TEMP-
+type: parsed
+protocol: NECext
+address: 86 6B 00 00
+command: 1E E1 00 00
+# 
+name: TIMER_SET
+type: parsed
+protocol: NECext
+address: 86 6B 00 00
+command: 05 FA 00 00
+# 
+name: TIMER_RESET
+type: parsed
+protocol: NECext
+address: 86 6B 00 00
+command: 08 F7 00 00


### PR DESCRIPTION
Exactly as the title describes.

I tested this with a Remko RKL 360 S-Line. The replacement IR remote had the other series listed as well, so it's the same for those models as well.