### PR TITLE
Add Samsung AA81-00243A Service Remote

### DIFF
--- a/TVs/Samsung/Samsung_AA81-00243A.ir
+++ b/TVs/Samsung/Samsung_AA81-00243A.ir
@@ -1,0 +1,66 @@
+Filetype: IR signals file
+Version: 1
+#
+# Samsung AA81-00243A
+# Service Remote Control
+# Send INFO and then FACTORY to open the service menu
+#
+name: Factory
+type: parsed
+protocol: Samsung32
+address: 07 00 00 00
+command: 3B 00 00 00
+# 
+name: POWER
+type: parsed
+protocol: Samsung32
+address: 07 00 00 00
+command: 02 00 00 00
+# 
+name: INFO
+type: parsed
+protocol: Samsung32
+address: 07 00 00 00
+command: 1F 00 00 00
+# 
+name: UP
+type: parsed
+protocol: Samsung32
+address: 07 00 00 00
+command: 60 00 00 00
+# 
+name: DOWN
+type: parsed
+protocol: Samsung32
+address: 07 00 00 00
+command: 61 00 00 00
+# 
+name: LEFT
+type: parsed
+protocol: Samsung32
+address: 07 00 00 00
+command: 65 00 00 00
+# 
+name: RIGHT
+type: parsed
+protocol: Samsung32
+address: 07 00 00 00
+command: 62 00 00 00
+# 
+name: OK
+type: parsed
+protocol: Samsung32
+address: 07 00 00 00
+command: 68 00 00 00
+# 
+name: EXIT
+type: parsed
+protocol: Samsung32
+address: 07 00 00 00
+command: 2D 00 00 00
+# 
+name: MENU
+type: parsed
+protocol: Samsung32
+address: 07 00 00 00
+command: 1A 00 00 00


### PR DESCRIPTION
Used by Samsung technician to fix TV https://www.amazon.com/AA81-00243A-Replaced-Service-Control-Samsung/dp/B07BFCC6S6