### PR TITLE
Added Phillips SWV9484B/27 HDMI Switch Remote Codes

### DIFF
--- a/Miscellaneous/Phillips/Pillips_swv9484b_hdmi_switch.ir
+++ b/Miscellaneous/Phillips/Pillips_swv9484b_hdmi_switch.ir
@@ -1,0 +1,26 @@
+Filetype: IR signals file
+Version: 1
+# 
+name: 1
+type: parsed
+protocol: NECext
+address: 82 FF 00 00
+command: 05 FA 00 00
+# 
+name: 2
+type: parsed
+protocol: NECext
+address: 82 FF 00 00
+command: 07 F8 00 00
+# 
+name: 3
+type: parsed
+protocol: NECext
+address: 82 FF 00 00
+command: 1B E4 00 00
+# 
+name: 4
+type: parsed
+protocol: NECext
+address: 82 FF 00 00
+command: 09 F6 00 00


### PR DESCRIPTION
These are the remote code for the [Phillips SWV9484B/27 4 Port HDMI Switch]. It comes with the tiniest of remotes that's easy to lose and figured I'd record the codes with my Flipper and contribute.

[Video Demo](https://youtu.be/BoI9RYNOFUg)
