### PR TITLE
Added Vornado OSCR37

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 *.ffs_db
+.vscode/

--- a/Fans/Vornado/Vornado_OSCR37.ir
+++ b/Fans/Vornado/Vornado_OSCR37.ir
@@ -1,0 +1,34 @@
+Filetype: IR signals file
+Version: 1
+#
+# Vornado OSCR37 Oscillating Tower Fan
+# 
+name: Power
+type: parsed
+protocol: NEC
+address: 03 00 00 00
+command: D8 00 00 00
+# 
+name: Speed_Up
+type: parsed
+protocol: NEC
+address: 03 00 00 00
+command: 4F 00 00 00
+# 
+name: Speed_Down
+type: parsed
+protocol: NEC
+address: 03 00 00 00
+command: 47 00 00 00
+# 
+name: Oscillate
+type: parsed
+protocol: NEC
+address: 03 00 00 00
+command: C3 00 00 00
+# 
+name: Timer
+type: parsed
+protocol: NEC
+address: 03 00 00 00
+command: 9B 00 00 00


### PR DESCRIPTION
This pull request adds the IR file for the Vornado OSCR37 oscillating tower fan. It also adds an exclusion in the gitignore file for VSCode files.