### PR TITLE
Create Orbegozo_RRE_1310_A.ir

### DIFF
--- a/Heaters/Orbegozo/Orbegozo_RRE_1310_A.ir
+++ b/Heaters/Orbegozo/Orbegozo_RRE_1310_A.ir
@@ -1,0 +1,29 @@
+Filetype: IR signals file
+Version: 1
+# 
+# Orbegozo RRE 1310 A Heater
+# https://orbegozo.com/productos/calefaccion/emisores-termicos/emisor-termico-rre-1310-a/
+# 
+name: Power
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 8C 00 00 00
+# 
+name: Menu
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 90 00 00 00
+# 
+name: +
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 98 00 00 00
+# 
+name: -
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 94 00 00 00


### PR DESCRIPTION
Added Orbegozo RRE 1310 A
Learned from the remote included in the package and tested to be working on the device.
The button layout looks very generic, so it is likely to work with other heaters from the same brand, specially those which are basically the same but with different size and wattage.
![orbegozo_remote](https://github.com/logickworkshop/Flipper-IRDB/assets/11365204/f200425c-92d6-408d-95c3-3f3d85302ef5)
