### PR TITLE
Added the protocol dump from my DynaScan DS2 digital sign remote control.

### DIFF
--- a/Digital_Signs/DynaScan/DS2/Dynascan_DS2.ir
+++ b/Digital_Signs/DynaScan/DS2/Dynascan_DS2.ir
@@ -1,0 +1,64 @@
+Filetype: IR signals file
+Version: 1
+# 
+# DynaScan DS2 remote control for city sidewalk digital signs.
+# 
+name: Gear
+type: parsed
+protocol: NECext
+address: 11 21 00 00
+command: 20 DF 00 00
+# 
+name: Power
+type: parsed
+protocol: NECext
+address: 11 21 00 00
+command: 21 DE 00 00
+# 
+name: Up
+type: parsed
+protocol: NECext
+address: 11 21 00 00
+command: 23 DC 00 00
+# 
+name: Down
+type: parsed
+protocol: NECext
+address: 11 21 00 00
+command: 27 D8 00 00
+# 
+name: Left
+type: parsed
+protocol: NECext
+address: 11 21 00 00
+command: 24 DB 00 00
+# 
+name: Right
+type: parsed
+protocol: NECext
+address: 11 21 00 00
+command: 26 D9 00 00
+# 
+name: Center
+type: parsed
+protocol: NECext
+address: 11 21 00 00
+command: 25 DA 00 00
+# 
+name: Back
+type: parsed
+protocol: NECext
+address: 11 21 00 00
+command: 28 D7 00 00
+# 
+name: Home
+type: parsed
+protocol: NECext
+address: 11 21 00 00
+command: 29 D6 00 00
+# 
+name: I
+type: parsed
+protocol: NECext
+address: 11 21 00 00
+command: 2A D5 00 00


### PR DESCRIPTION
Last year the city I live in joined the [IKE Smart City initiative](https://www.ikesmartcity.com/) and set up hardened digital sign kiosks on the sidewalks.  I did some research on them and found out that the signs are based upon DynaScan DS2 digital displays.  It took me a bit but I tracked down one of the remote controls used for these signs.  This PR came from my Flipper Zero, with the following buttons:

* Gear - configuration
* Power - power
* Up, Down, Left, Right - cursor keys for the on-screen menus
* Center - select button, not unlike a left-click
* Back - cancel or drop back a menu
* Home - go back to the home menu
* I - I don't know what this does yet

The layout of the DS2 remote is not very different from that of a Firestick.  However, I tried to keep the names accurate to the icons on the buttons themselves.